### PR TITLE
Add JSON-backed settings store

### DIFF
--- a/SmartHomeDashboard/Program.cs
+++ b/SmartHomeDashboard/Program.cs
@@ -13,6 +13,7 @@ builder.Services.Configure<MonitorOptions>(builder.Configuration.GetSection("Mon
 // Persistence + background services
 builder.Services.AddSingleton<DeviceRepository>();
 builder.Services.AddSingleton<LogsRepository>();
+builder.Services.AddSingleton<AppSettingsStore>();
 builder.Services.AddHostedService<DeviceMonitorService>();
 
 var app = builder.Build();
@@ -25,6 +26,9 @@ using (var scope = app.Services.CreateScope())
 
     var logs = scope.ServiceProvider.GetRequiredService<LogsRepository>();
     _ = logs.GetTail(1);  // triggers logs.json creation if needed
+
+    var settings = scope.ServiceProvider.GetRequiredService<AppSettingsStore>();
+    _ = settings.GetMonitor(); // triggers settings.json creation if needed
 }
 
 if (!app.Environment.IsDevelopment())

--- a/SmartHomeDashboard/Repositories/AppSettingsStore.cs
+++ b/SmartHomeDashboard/Repositories/AppSettingsStore.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using SmartHomeDashboard.Models.Options;
+
+namespace SmartHomeDashboard.Repositories
+{
+    /// <summary>
+    /// JSON-backed store for editable application settings.
+    /// Currently only stores Monitor options in App_Data/settings.json.
+    /// Thread-safe via a private lock and in-memory cache.
+    /// </summary>
+    public class AppSettingsStore
+    {
+        private readonly string _dataDir;
+        private readonly string _settingsFilePath;
+        private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+        private readonly object _sync = new();
+        private MonitorOptions _monitor = new();
+
+        public AppSettingsStore(IOptions<MonitorOptions> defaults, IWebHostEnvironment env)
+        {
+            if (defaults is null) throw new ArgumentNullException(nameof(defaults));
+            if (env is null) throw new ArgumentNullException(nameof(env));
+
+            _dataDir = Path.Combine(env.ContentRootPath, "App_Data");
+            _settingsFilePath = Path.Combine(_dataDir, "settings.json");
+
+            EnsureStorage();
+            LoadOrSeed(defaults.Value);
+        }
+
+        /// <summary>Return a deep copy of current monitor settings.</summary>
+        public MonitorOptions GetMonitor()
+        {
+            lock (_sync)
+            {
+                return Clone(_monitor);
+            }
+        }
+
+        /// <summary>
+        /// Validate and persist monitor settings.
+        /// Returns true on success with a diff of changes; false sets errorMessage.
+        /// </summary>
+        public bool TrySaveMonitor(MonitorOptions input,
+            out Dictionary<string, (string? OldValue, string? NewValue)>? changes,
+            out string? errorMessage)
+        {
+            changes = null;
+            errorMessage = null;
+
+            var context = new ValidationContext(input);
+            var results = new List<ValidationResult>();
+            if (!Validator.TryValidateObject(input, context, results, true))
+            {
+                errorMessage = string.Join("; ", results.Select(r => r.ErrorMessage));
+                return false;
+            }
+
+            lock (_sync)
+            {
+                var diff = BuildDiff(_monitor, input);
+                var next = Clone(input);
+                try
+                {
+                    Persist(next);
+                    _monitor = next;
+                    changes = diff;
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    errorMessage = ex.Message;
+                    return false;
+                }
+            }
+        }
+
+        // ------------------- internals -------------------
+
+        private void EnsureStorage()
+        {
+            if (!Directory.Exists(_dataDir)) Directory.CreateDirectory(_dataDir);
+        }
+
+        private void LoadOrSeed(MonitorOptions defaults)
+        {
+            try
+            {
+                if (File.Exists(_settingsFilePath))
+                {
+                    var json = File.ReadAllText(_settingsFilePath);
+                    var dto = string.IsNullOrWhiteSpace(json)
+                        ? null
+                        : JsonSerializer.Deserialize<Root>(json, _jsonOptions);
+                    _monitor = dto?.Monitor ?? Clone(defaults);
+                }
+                else
+                {
+                    _monitor = Clone(defaults);
+                    Persist(_monitor); // create file with defaults
+                }
+            }
+            catch
+            {
+                _monitor = Clone(defaults);
+            }
+        }
+
+        private void Persist(MonitorOptions monitor)
+        {
+            var dto = new Root { Monitor = monitor };
+            var json = JsonSerializer.Serialize(dto, _jsonOptions);
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, json);
+            File.Copy(tmp, _settingsFilePath, overwrite: true);
+            File.Delete(tmp);
+        }
+
+        private static MonitorOptions Clone(MonitorOptions src) => new()
+        {
+            PollIntervalSeconds = src.PollIntervalSeconds,
+            PingTimeoutMs = src.PingTimeoutMs,
+            TcpFallbackEnabled = src.TcpFallbackEnabled,
+            TcpPorts = src.TcpPorts is null ? new List<int>() : new List<int>(src.TcpPorts)
+        };
+
+        private static Dictionary<string, (string? OldValue, string? NewValue)> BuildDiff(
+            MonitorOptions current, MonitorOptions input)
+        {
+            var diff = new Dictionary<string, (string?, string?)>();
+
+            if (current.PollIntervalSeconds != input.PollIntervalSeconds)
+                diff["PollIntervalSeconds"] = (current.PollIntervalSeconds.ToString(), input.PollIntervalSeconds.ToString());
+
+            if (current.PingTimeoutMs != input.PingTimeoutMs)
+                diff["PingTimeoutMs"] = (current.PingTimeoutMs.ToString(), input.PingTimeoutMs.ToString());
+
+            if (current.TcpFallbackEnabled != input.TcpFallbackEnabled)
+                diff["TcpFallbackEnabled"] = (current.TcpFallbackEnabled.ToString(), input.TcpFallbackEnabled.ToString());
+
+            var currentPorts = current.TcpPorts ?? new List<int>();
+            var inputPorts = input.TcpPorts ?? new List<int>();
+            if (!currentPorts.SequenceEqual(inputPorts))
+                diff["TcpPorts"] = (FormatPorts(currentPorts), FormatPorts(inputPorts));
+
+            return diff;
+        }
+
+        private static string? FormatPorts(List<int> ports)
+        {
+            return ports.Count == 0 ? null : string.Join(",", ports);
+        }
+
+        private class Root
+        {
+            public MonitorOptions Monitor { get; set; } = new();
+        }
+    }
+}
+

--- a/SmartHomeDashboard/Views/Settings/Index.cshtml
+++ b/SmartHomeDashboard/Views/Settings/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model SmartHomeDashboard.Models.Options.MonitorOptions
+@model SmartHomeDashboard.Controllers.SettingsViewModel
 @{
     ViewData["Title"] = "Settings";
 }
@@ -6,59 +6,56 @@
 <section class="mb-4">
     <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2">
         <h1 class="h3 m-0">Settings</h1>
-
         <div class="d-flex align-items-center gap-2">
             <a asp-controller="Settings" asp-action="DownloadLogsJson" class="btn btn-outline-secondary">Download logs (JSON)</a>
             <a asp-controller="Settings" asp-action="DownloadLogsExcel" class="btn btn-primary">Download logs (Excel)</a>
         </div>
     </div>
 
-    <p class="text-secondary mb-3">
-        Read-only for now. These values are loaded from <code class="log-code">appsettings.json</code>. Editing is scaffolded below but intentionally disabled in this build.
-    </p>
+    @if (TempData["ToastSuccess"] != null)
+    {
+        <div class="alert alert-success" role="alert">
+            @TempData["ToastSuccess"]
+        </div>
+    }
 
     <div class="shd-card p-3">
-        <form asp-controller="Settings" asp-action="Index" method="post" class="row g-3">
+        <form asp-action="Index" method="post" class="row g-3">
             @Html.AntiForgeryToken()
-
-            <div class="col-12">
-                <div class="alert alert-warning m-0">
-                    <strong>Read-only:</strong> Editing is disabled in this build. Controls are shown for preview only.
-                </div>
-            </div>
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
             <div class="col-12 col-md-6">
-                <label for="PollIntervalSeconds" class="form-label">Monitor poll interval (seconds)</label>
-                <input id="PollIntervalSeconds" name="PollIntervalSeconds" type="number" class="form-control"
-                       value="@Model.PollIntervalSeconds" min="5" max="3600" disabled />
+                <label asp-for="PollIntervalSeconds" class="form-label"></label>
+                <input asp-for="PollIntervalSeconds" class="form-control" type="number" min="5" max="3600" />
                 <div class="form-text">How often the background monitor runs (5–3600).</div>
+                <span asp-validation-for="PollIntervalSeconds" class="text-danger"></span>
             </div>
 
             <div class="col-12 col-md-6">
-                <label for="PingTimeoutMs" class="form-label">Ping timeout (ms)</label>
-                <input id="PingTimeoutMs" name="PingTimeoutMs" type="number" class="form-control"
-                       value="@Model.PingTimeoutMs" min="100" max="10000" step="50" disabled />
+                <label asp-for="PingTimeoutMs" class="form-label"></label>
+                <input asp-for="PingTimeoutMs" class="form-control" type="number" min="100" max="10000" />
                 <div class="form-text">ICMP ping timeout per device (100–10000).</div>
+                <span asp-validation-for="PingTimeoutMs" class="text-danger"></span>
             </div>
 
             <div class="col-12 col-md-6">
                 <div class="form-check">
-                    <input id="TcpFallbackEnabled" name="TcpFallbackEnabled" class="form-check-input" type="checkbox"
-                           @(Model.TcpFallbackEnabled ? "checked" : "") disabled />
-                    <label class="form-check-label" for="TcpFallbackEnabled">Enable TCP fallback when ICMP is blocked</label>
+                    <input asp-for="TcpFallbackEnabled" class="form-check-input" type="checkbox" />
+                    <label asp-for="TcpFallbackEnabled" class="form-check-label"></label>
                 </div>
                 <div class="form-text">If enabled, a quick TCP probe will be attempted when ping fails.</div>
+                <span asp-validation-for="TcpFallbackEnabled" class="text-danger"></span>
             </div>
 
             <div class="col-12 col-md-6">
-                <label for="TcpPorts" class="form-label">TCP ports to try</label>
-                <input id="TcpPorts" name="TcpPorts" type="text" class="form-control"
-                       value="@(string.Join(", ", Model.TcpPorts ?? new List<int>()))" disabled />
+                <label asp-for="TcpPortsCsv" class="form-label"></label>
+                <input asp-for="TcpPortsCsv" class="form-control" placeholder="80, 443" />
                 <div class="form-text">Comma-separated; used only when TCP fallback is enabled.</div>
+                <span asp-validation-for="TcpPortsCsv" class="text-danger"></span>
             </div>
 
             <div class="col-12 d-flex align-items-center gap-2">
-                <button type="submit" class="btn btn-success" disabled title="Editing disabled in this build">Save changes</button>
+                <button type="submit" class="btn btn-primary">Save changes</button>
                 <a asp-controller="Home" asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- add AppSettingsStore to persist monitor settings to App_Data/settings.json
- register AppSettingsStore in DI and warm startup to seed settings file
- enable saving and logging of monitor settings via SettingsController
- replace Settings view with editable form bound to SettingsViewModel

## Testing
- `dotnet build SmartHomeDashboard.sln`
- `timeout 5 dotnet run --project SmartHomeDashboard`


------
https://chatgpt.com/codex/tasks/task_e_68bfce182ca4832f8028ed4ae266105c